### PR TITLE
Change default file extensions in pre-commit-hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
   language: python
   language_version: python3
   entry: curlylint
-  types: [jinja]
+  files: '\.(html|jinja|twig)$'

--- a/website/docs/reference/integrations.md
+++ b/website/docs/reference/integrations.md
@@ -20,12 +20,10 @@ Add to your `.pre-commit-config.yaml`:
 
 Make sure to fill in the `rev` with a valid revision.
 
-_Note_: by default this configuration will only match `.jinja` and `.jinja2`
-files. To match by regex pattern instead, override `types` and `files` as
-follows:
+_Note_: by default this configuration will match `.html`, `.jinja`, and `.twig` files.
+If you want to override this, you will need to use the `files` setting.  For example:
 
 ```yaml
 - id: curlylint
-  types: [file] # restore the default `types` matching
   files: \.(html|sls)$
 ```

--- a/website/docs/reference/integrations.md
+++ b/website/docs/reference/integrations.md
@@ -21,7 +21,7 @@ Add to your `.pre-commit-config.yaml`:
 Make sure to fill in the `rev` with a valid revision.
 
 _Note_: by default this configuration will match `.html`, `.jinja`, and `.twig` files.
-If you want to override this, you will need to use the `files` setting.  For example:
+If you want to override this, you will need to use the `files` setting. For example:
 
 ```yaml
 - id: curlylint


### PR DESCRIPTION
At the moment it will only work on jinja template files, but Django templates are normally with a plain .html extension so using curlylint as a pre-commit hook doesn't work.