### PR TITLE
Fix off-by-one line number in compact output

### DIFF
--- a/curlylint/issue.py
+++ b/curlylint/issue.py
@@ -12,7 +12,7 @@ class IssueLocation:
     line = attr.ib()
 
     def __str__(self):
-        return "{}:{}:{}".format(self.file_path, self.line + 1, self.column)
+        return "{}:{}:{}".format(self.file_path, self.line, self.column)
 
     @staticmethod
     def from_ast(file_path, line, column):


### PR DESCRIPTION
Line numbers in compact output are higher by one compared to json and stylish outputs. This fixes that.

The `+ 1` looks intentional so was worried this change could break something else. However `IssueLocation.__str__()` is only called from `Issue.__str__()` which is only used in `format_compact()` so this should be safe.

Lint and tests pass.