### PR TITLE
fix: command and args typo in website/docs

### DIFF
--- a/website/docs/command-line-usage.md
+++ b/website/docs/command-line-usage.md
@@ -96,7 +96,7 @@ curlylint --template-tags '[["cache", "endcache"]]' template-directory/
 Read configuration from the provided file.
 
 ```bash
-curlylint--config test_pyproject.toml template-directory/
+curlylint --config test_pyproject.toml template-directory/
 ```
 
 ## Reading from standard input


### PR DESCRIPTION
## Description

I found a command and args typo in the documentation and fixed it. 🙇

- <https://www.curlylint.org/docs/command-line-usage#--config>

## Misc

On a different note, I made a plugin(extension) that allows curlylint to work with my Vim(coc.nvim). 😇

- <https://github.com/yaegassy/coc-curlylint>

![coc-curlylint-demo](https://user-images.githubusercontent.com/188642/116181136-0b629180-a755-11eb-93c8-b37d16689b38.gif)
