### PR TITLE
Update parsy to 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "parsy==1.1.0",
+        "parsy==1.3.0",
         "attrs>=17.2.0",
         "click>=6.5",
         "toml>=0.9.4",


### PR DESCRIPTION
Hi!

I just updated parsy to 1.3.0 for following message raised.

```
The conflict is caused by:
    curlylint 0.13.0 depends on parsy==1.1.0
    The user requested (constraint) parsy==1.3.0
```
