### PR TITLE
Re-imported rules docs

### DIFF
--- a/website/build_rules.py
+++ b/website/build_rules.py
@@ -233,7 +233,8 @@ import CodeSnippet from "@theme/CodeSnippet";
 
 {fail_section}
 
-{resources_section}"""
+{resources_section}
+"""
             )
 
     rules_list = "\n".join(
@@ -247,9 +248,9 @@ import CodeSnippet from "@theme/CodeSnippet";
     with codecs.open("rules-sidebar.js", "w", "utf-8") as file:
         file.write(
             f"""module.exports = [
-    {rules_id}
+  {rules_id}
 ];
-        """
+"""
         )
 
     all_config_toml = []

--- a/website/docs/rules/all.mdx
+++ b/website/docs/rules/all.mdx
@@ -15,8 +15,8 @@ import CodeSnippet from "@theme/CodeSnippet";
 - [image_alt](image_alt): `<img>` elements must have a `alt` attribute, either with meaningful text, or an empty string for decorative images
 - [indent](indent): Enforce consistent indentation
 - [meta_viewport](meta_viewport): The `viewport` meta tag should not use `user-scalable=no`, and `maximum-scale` should be 2 or above, so end users can zoom
-- [no_autofocus](no_autofocus): Enforce autofocus is not used on inputs. Autofocusing elements can cause usability issues for sighted and non-sighted users.
-- [tabindex_no_positive](tabindex_no_positive): Enforce autofocus is not used on inputs. Autofocusing elements can cause usability issues for sighted and non-sighted users.
+- [no_autofocus](no_autofocus): Enforce autofocus is not used on inputs.  Autofocusing elements can cause usability issues for sighted and non-sighted users.
+- [tabindex_no_positive](tabindex_no_positive): Prevents using positive `tabindex` values, which are very easy to misuse with problematic consequences for keyboard users.
 
 ## Try them all
 

--- a/website/docs/rules/aria_role.mdx
+++ b/website/docs/rules/aria_role.mdx
@@ -65,6 +65,7 @@ This rule supports the following configuration:
   </TabItem>
 </Tabs>
 
+
 ## Fail
 
 <Tabs
@@ -90,6 +91,7 @@ This rule supports the following configuration:
     />
   </TabItem>
 </Tabs>
+
 
 ## Resources
 

--- a/website/docs/rules/django_forms_rendering.mdx
+++ b/website/docs/rules/django_forms_rendering.mdx
@@ -65,6 +65,7 @@ This rule supports the following configuration:
   </TabItem>
 </Tabs>
 
+
 ## Fail
 
 <Tabs
@@ -90,6 +91,7 @@ This rule supports the following configuration:
     />
   </TabItem>
 </Tabs>
+
 
 ## Resources
 

--- a/website/docs/rules/html_has_lang.mdx
+++ b/website/docs/rules/html_has_lang.mdx
@@ -65,6 +65,7 @@ This rule supports the following configuration:
   </TabItem>
 </Tabs>
 
+
 ## Fail
 
 <Tabs
@@ -90,6 +91,7 @@ This rule supports the following configuration:
     />
   </TabItem>
 </Tabs>
+
 
 ## Resources
 

--- a/website/docs/rules/image_alt.mdx
+++ b/website/docs/rules/image_alt.mdx
@@ -65,6 +65,7 @@ This rule supports the following configuration:
   </TabItem>
 </Tabs>
 
+
 ## Fail
 
 <Tabs
@@ -90,6 +91,7 @@ This rule supports the following configuration:
     />
   </TabItem>
 </Tabs>
+
 
 ## Resources
 

--- a/website/docs/rules/indent.mdx
+++ b/website/docs/rules/indent.mdx
@@ -39,6 +39,10 @@ This rule supports the following configuration:
   </TabItem>
 </Tabs>
 
+
+
+
+
 ## Resources
 
 - Known issue: [Allow indentation inside template tags](https://github.com/thibaudcolas/curlylint/issues/6)

--- a/website/docs/rules/meta_viewport.mdx
+++ b/website/docs/rules/meta_viewport.mdx
@@ -65,6 +65,7 @@ This rule supports the following configuration:
   </TabItem>
 </Tabs>
 
+
 ## Fail
 
 <Tabs
@@ -90,6 +91,7 @@ This rule supports the following configuration:
     />
   </TabItem>
 </Tabs>
+
 
 ## Resources
 

--- a/website/docs/rules/no_autofocus.mdx
+++ b/website/docs/rules/no_autofocus.mdx
@@ -9,7 +9,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeSnippet from "@theme/CodeSnippet";
 
-> Enforce autofocus is not used on inputs. Autofocusing elements can cause usability issues for sighted and non-sighted users.
+> Enforce autofocus is not used on inputs.  Autofocusing elements can cause usability issues for sighted and non-sighted users.
 >
 > User impact: **Serious**
 
@@ -65,6 +65,7 @@ This rule supports the following configuration:
   </TabItem>
 </Tabs>
 
+
 ## Fail
 
 <Tabs
@@ -90,6 +91,7 @@ This rule supports the following configuration:
     />
   </TabItem>
 </Tabs>
+
 
 ## Resources
 

--- a/website/docs/rules/tabindex_no_positive.mdx
+++ b/website/docs/rules/tabindex_no_positive.mdx
@@ -9,7 +9,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeSnippet from "@theme/CodeSnippet";
 
-> Enforce autofocus is not used on inputs. Autofocusing elements can cause usability issues for sighted and non-sighted users.
+> Prevents using positive `tabindex` values, which are very easy to misuse with problematic consequences for keyboard users.
 >
 > User impact: **Serious**
 
@@ -65,6 +65,7 @@ This rule supports the following configuration:
   </TabItem>
 </Tabs>
 
+
 ## Fail
 
 <Tabs
@@ -90,6 +91,7 @@ This rule supports the following configuration:
     />
   </TabItem>
 </Tabs>
+
 
 ## Resources
 

--- a/website/rules-sidebar.js
+++ b/website/rules-sidebar.js
@@ -6,5 +6,5 @@ module.exports = [
   "rules/indent",
   "rules/meta_viewport",
   "rules/no_autofocus",
-  "rules/tabindex_no_positive",
+  "rules/tabindex_no_positive"
 ];


### PR DESCRIPTION
I noticed the live `tabindex_no_positive` docs are copypasta from `no_autofocus`: "Enforce autofocus is not used on inputs.". This was fixed in 994e3644c802edeeb6a3d7cfaa443c263dee3aa8 but not reimported to the docs site.

I ran `build_rules.py` but this needed a few whitespace fixes to (mostly) match the existing generated files. I think some changes were made in a09e5b0bfbb5bc1a122bf7df50152d207a562355 without rerunning the `build_rules.py` so this PR updates for them.