### PR TITLE
Fix Mypy

### DIFF
--- a/curlylint/cli.py
+++ b/curlylint/cli.py
@@ -288,13 +288,13 @@ def patch_click() -> None:
     """
     try:
         from click import core
-        from click import _unicodefun  # type: ignore
+        from click import _unicodefun
     except ModuleNotFoundError:
         return
 
     for module in (core, _unicodefun):
         if hasattr(module, "_verify_python3_env"):
-            module._verify_python3_env = lambda: None
+            module._verify_python3_env = lambda: None  # type: ignore [attr-defined]
 
 
 def patched_main() -> None:

--- a/curlylint/config.py
+++ b/curlylint/config.py
@@ -107,7 +107,7 @@ def read_pyproject_toml(
 
     if ctx.default_map is None:
         ctx.default_map = {}
-    ctx.default_map.update(config)  # type: ignore  # bad types in .pyi
+    ctx.default_map.update(config)
     return value
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,8 @@ disallow_untyped_decorators = True
 
 # Warns about casting an expression to its inferred type.
 warn_redundant_casts = True
+# Shows error codes
+show_error_codes = True
 # Warns about unneeded # type: ignore comments.
 warn_unused_ignores = True
 # Shows errors for missing return statements on some execution paths.


### PR DESCRIPTION
Fix these errors which were happening on `make lint`:

```
curlylint/config.py:110: error: unused 'type: ignore' comment
curlylint/cli.py:291: error: unused 'type: ignore' comment
curlylint/cli.py:297: error: Module has no attribute "_verify_python3_env"
Found 3 errors in 2 files (checked 20 source files)
```

Adding `show_error_codes` and ignoring by error code as per [this post](https://adamj.eu/tech/2021/05/25/python-type-hints-specific-type-ignore/).