### PR TITLE
Add pre-commit option require_serial

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,4 @@
   language_version: python3
   entry: curlylint
   files: '\.(html|jinja|twig)$'
+  require_serial: true


### PR DESCRIPTION
By default, pre-commit splits the files it wants to lint into one list per processor and launches one tool process for each. Since curlylint performs parallelization internally, this behaviour leads to a detrimental explosion of N * N processes. Setting [`require_serial: true`](https://pre-commit.com/#hooks-require_serial) in the hook definition disables pre-commit's parallelization.

Black is in the same situation and sets `require_serial: true`: https://github.com/psf/black/blob/main/.pre-commit-hooks.yaml .