### PR TITLE
Make use of forward_declaration from Parsy 1.4 for cleanup

### DIFF
--- a/curlylint/parse.py
+++ b/curlylint/parse.py
@@ -706,12 +706,7 @@ def make_parser(config=None):
     if config is None:
         config = {}
 
-    content_ = None
-
-    @P.generate
-    def content():
-        c = yield content_
-        return c
+    content = P.forward_declaration()
 
     jinja = make_jinja_parser(config, content)
 
@@ -719,16 +714,18 @@ def make_parser(config=None):
 
     opt_container = make_jinja_optional_container_parser(config, content, jinja)
 
-    content_ = interpolated(
-        (
-            quick_text
-            | comment
-            | dtd
-            | element
-            | opt_container
-            | jinja
-            | slow_text_char
-        ).many()
+    content.become(
+        interpolated(
+            (
+                quick_text
+                | comment
+                | dtd
+                | element
+                | opt_container
+                | jinja
+                | slow_text_char
+            ).many()
+        )
     )
 
-    return {"content": content_, "jinja": jinja, "element": element}
+    return {"content": content, "jinja": jinja, "element": element}

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "parsy==1.1.0",
+        "parsy>=1.4.0",
         "attrs>=17.2.0",
         "click>=6.5",
         "toml>=0.9.4",


### PR DESCRIPTION
I'm the maintainer of Parsy (although not the original author) and I came across curlylint - I think it is one of the most advanced uses of Parsy I've found! Anyway, I happened to see this bit of code that can be cleaned up a bit with a feature from 1.4 - https://parsy.readthedocs.io/en/latest/ref/primitives.html#parsy.forward_declaration

This PR also loosens the dependency from `==` to `>=`, which might more friendly for users in some situations, although I can also see you might want to pin it for your use case. FWIW, as the maintainer I'm very conservative with breaking changes for this library. In version 2.0 I dropped support for Python < 3.6, other than that it's very rare I break anything deliberately. 

Also, if you wanted, I could include testing against curlylint's test suite for regression testing, as part of Parsy's own test suite - it might help both projects.

There's a linting failure, but it's happening on `main` as well.