### PR TITLE
fix: allow whitespace before closing ">"

### DIFF
--- a/curlylint/parse.py
+++ b/curlylint/parse.py
@@ -447,7 +447,10 @@ def _combine_closing_tag(locations, name):
 
 def make_closing_tag_parser(tag_name_parser):
     return locate(
-        P.string("</").then(tag_name_parser).skip(P.string(">"))
+        P.string("</")
+        .then(tag_name_parser)
+        .skip(whitespace)
+        .skip(P.string(">"))
     ).combine(_combine_closing_tag)
 
 


### PR DESCRIPTION
Don't throw up on correct HTML.
