### PR TITLE
Fix copy/paste error in docs

### DIFF
--- a/website/docs/template-languages.md
+++ b/website/docs/template-languages.md
@@ -32,7 +32,7 @@ Can be used as a Twig linter, since the syntax is very similar. All HTML checks 
 
 ## [Liquid](https://shopify.github.io/liquid/)
 
-Can be used as a Liquid linter, since the syntax is very similar. All HTML checks should work as expected. Template syntax checks may be problematic. Curlylint isn’t as well tested on Liquid, but bug reports are definitely appreciated and we would love to have good support for Twig.
+Can be used as a Liquid linter, since the syntax is very similar. All HTML checks should work as expected. Template syntax checks may be problematic. Curlylint isn’t as well tested on Liquid, but bug reports are definitely appreciated and we would love to have good support for Liquid.
 
 ## HTML
 


### PR DESCRIPTION
Vestigial reference to Twig changed to Liquid.
Noticed this while browsing your docs looking for a Liquid template linter :) 

--- 

[x] Create your branch from the up to date `main` branch.
~~[] If you've added code, add tests!~~
~~3. If you've changed APIs, update the documentation.~~
[x] Ensure that:
- The test suite passes
- The linting passes


